### PR TITLE
Align published version with tgbotapi

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,10 @@ plugins {
     kotlin("jvm") version "2.2.0"
 }
 
+val tgbotapiVersion = "27.1.2"
+
 group = "me.centralhardware"
-version = "1.0-SNAPSHOT"
+version = tgbotapiVersion
 
 repositories {
     mavenCentral()
@@ -16,7 +18,7 @@ dependencies {
     implementation("org.apache.commons:commons-lang3:3.18.0")
 
     implementation("dev.inmo:kslog:1.5.0")
-    implementation("dev.inmo:tgbotapi:27.1.2")
+    implementation("dev.inmo:tgbotapi:$tgbotapiVersion")
     implementation("com.github.centralhardware:ktgbotapi-clickhouse-logging-middleware:50869a92bf")
     implementation("com.github.centralhardware:ktgbotapi-stdout-logging-middleware:704657ed0d")
 }
@@ -33,8 +35,9 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "me.centralhardware"
             artifactId = "bot-common"
-            version = "1.0-SNAPSHOT"
+            version = tgbotapiVersion
             from(components["java"])
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- use a single `tgbotapiVersion` constant for dependencies and project version
- publish the library with the same version as the tgbotapi dependency

## Testing
- `./gradlew test` *(fails: Dependency resolution is looking for a library compatible with JVM runtime version 21, but 'root project :' is only compatible with JVM runtime version 24 or newer)*
- `./gradlew :test`


------
https://chatgpt.com/codex/tasks/task_e_689439e989dc83259b9e4fb13991a32c