### PR TITLE
Remove logback-classic from integration-test-bot

### DIFF
--- a/integration-test-bot/build.gradle.kts
+++ b/integration-test-bot/build.gradle.kts
@@ -14,7 +14,6 @@ repositories {
 dependencies {
     implementation(project(":ktgbotapi-commons-core"))
     implementation("dev.inmo:tgbotapi:34.0.0")
-    runtimeOnly("ch.qos.logback:logback-classic:1.5.12")
 }
 
 application {


### PR DESCRIPTION
Removes the `runtimeOnly("ch.qos.logback:logback-classic")` dependency from `integration-test-bot`.

Logback was the only place in the whole project where a concrete SLF4J/kslog backend was declared — none of the published modules depend on it. This drops it from the test bot too.

Note: makes dependabot PR #98 (bump logback 1.5.12 → 1.5.34) obsolete. Side effect: the integration test bot no longer has an SLF4J provider, so kslog/slf4j output won't be written when running it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)