### PR TITLE
Update ktgbotapi to 35.1.0

### DIFF
--- a/ktgbotapi-commons-core/build.gradle.kts
+++ b/ktgbotapi-commons-core/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 group = "me.centralhardware"
 
-val ktgbotapiVersion = "35.0.0"
+val ktgbotapiVersion = "35.1.0"
 
 dependencies {
     implementation("org.apache.commons:commons-lang3:3.20.0")


### PR DESCRIPTION
Bumps `dev.inmo:tgbotapi` from 35.0.0 to 35.1.0 (latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)